### PR TITLE
fix(Azure): Ignore files not in latest iteration

### DIFF
--- a/src/AzureDevOpsClient.js
+++ b/src/AzureDevOpsClient.js
@@ -155,7 +155,6 @@ function makeReview(diff, options) {
               iterationId
             )
             .then(({ changeEntries }) => {
-              let latestChangeTrackingId = 1;
               const changes = !changeEntries
                 ? {}
                 : changeEntries.reduce(
@@ -163,11 +162,7 @@ function makeReview(diff, options) {
                     (changes, change) => {
                       const filePath = getItemPath(change);
                       if (filePath) {
-                        const changeTrackingId = change.changeTrackingId || 1;
-                        changes[filePath] = changeTrackingId;
-                        if (changeTrackingId > latestChangeTrackingId) {
-                          latestChangeTrackingId = changeTrackingId;
-                        }
+                        changes[filePath] = change.changeTrackingId || 1;
                       }
                       return changes;
                     },

--- a/tests/AzureDevOpsClient.test.js
+++ b/tests/AzureDevOpsClient.test.js
@@ -262,7 +262,7 @@ describe("AzureDevOpsClient", () => {
     expect(payload).toEqual(FIXTURE_PIPED_ADO_PAYLOAD);
   });
 
-  test("handles zero change entries", async () => {
+  test("ignores files not in latest iteration", async () => {
     /** @type {GitPullRequestCommentThread[]} */
     let payloads = [];
     await makeReview(
@@ -275,15 +275,7 @@ describe("AzureDevOpsClient", () => {
         getPullRequestIterationChanges: () => Promise.resolve({}),
       })
     );
-    expect(payloads).toHaveLength(FIXTURE_UNIDIFF_ADO_PAYLOAD.length);
-    expect(payloads[0]).toEqual(FIXTURE_UNIDIFF_ADO_PAYLOAD[0]);
-    expect(
-      FIXTURE_UNIDIFF_ADO_PAYLOAD[1].pullRequestThreadContext.changeTrackingId
-    ).toBe(2);
-    expect(
-      payloads[1].pullRequestThreadContext &&
-        payloads[1].pullRequestThreadContext.changeTrackingId
-    ).toBe(1);
+    expect(payloads).toHaveLength(0);
   });
 
   test("dumps the exception on failure", async () => {


### PR DESCRIPTION
It doesn't seem like ADO supports suggestions to files that have not been changed in the latest iteration. Suggestions are attached to seemingly random files on random lines.