### PR TITLE
fix(GitHub): lineLength not defined in DraftPullRequestReviewThread

### DIFF
--- a/src/GitHubClient.js
+++ b/src/GitHubClient.js
@@ -30,6 +30,20 @@ function makeOctokit(options) {
 }
 
 /**
+ * Trims comment for fields not defined in DraftPullRequestReviewThread.
+ *
+ * GitHub type checks the payload sent to it and fails the request if there are
+ * unknown fields.
+ *
+ * @param {import("./makeComments").Comment} comment
+ * @returns {Omit<import("./makeComments").Comment, "line_length">}
+ */
+// eslint-disable-next-line no-unused-vars
+function trimComment({ line_length, ...rest }) {
+  return rest;
+}
+
+/**
  * Submits a code review with suggestions with specified diff and options.
  * @param {string} diff
  * @param {Options} [options]
@@ -70,7 +84,7 @@ function makeReview(diff, options) {
     repo,
     pull_number: getPullRequestNumber(GITHUB_EVENT_PATH),
     event: c("COMMENT"),
-    comments,
+    comments: comments.map(trimComment),
   };
   return makeOctokit({ auth: GITHUB_TOKEN, ...options })
     .pulls.createReview(review)

--- a/tests/__fixtures__.js
+++ b/tests/__fixtures__.js
@@ -80,7 +80,6 @@ module.exports["FIXTURE_PIPED_GH_PAYLOAD"] = {
     {
       path: "src/GitHubClient.js",
       line: 95,
-      line_length: 65,
       side: "RIGHT",
       body: concatStrings(
         "```suggestion",
@@ -195,7 +194,6 @@ module.exports["FIXTURE_UNIDIFF_GH_PAYLOAD"] = {
     {
       path: "src/Graphics/TextureAllocator.gl.h",
       line: 22,
-      line_length: 59,
       side: "RIGHT",
       start_line: 21,
       start_side: "RIGHT",
@@ -209,7 +207,6 @@ module.exports["FIXTURE_UNIDIFF_GH_PAYLOAD"] = {
     {
       path: "src/Graphics/VertexArray.h",
       line: 56,
-      line_length: 10,
       side: "RIGHT",
       start_line: 53,
       start_side: "RIGHT",


### PR DESCRIPTION
GitHub fails the request with the following error message if there are unknown fields in the payload:

RequestError [HttpError]: Unprocessable Entity: "Variable $threads of type [DraftPullRequestReviewThread] was provided invalid value for ...