### PR TITLE
chore: increase stability days for dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,6 @@
   "labels": ["dependencies"],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rangeStrategy": "update-lockfile",
+  "stabilityDays": 7,
   "timezone": "Europe/Oslo"
 }


### PR DESCRIPTION
Increase number of days before a dependency is updated: https://docs.renovatebot.com/configuration-options/#stabilitydays